### PR TITLE
Added managementAptInstallSpecific and managementAptDeinstallSpecific…

### DIFF
--- a/src/IpcClient.h
+++ b/src/IpcClient.h
@@ -117,6 +117,11 @@ private:
     Ipc::PVariable systemUpdateAvailable(Ipc::PArray& parameters);
     // }}}
 
+    // {{{ Package management
+    Ipc::PVariable aptInstallSpecific(Ipc::PArray& parameters);
+    Ipc::PVariable aptDeinstallSpecific(Ipc::PArray& parameters);
+    // }}}
+
     // {{{ Backups
     Ipc::PVariable createBackup(Ipc::PArray& parameters);
     Ipc::PVariable restoreBackup(Ipc::PArray& parameters);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -54,6 +54,7 @@ void Settings::reset()
     _allowedServiceCommands.clear();
     _controllableServices.clear();
 	_packagesWhitelist.clear();
+	_packagesBlacklist.clear();
     _settingsWhitelist.clear();
 }
 
@@ -68,6 +69,8 @@ bool Settings::changed()
 
 void Settings::load(std::string filename, std::string executablePath)
 {
+	constexpr std::array<const char*, 31> blackList {{"wget", "libsqlite3-0", "libreadline7", "libreadline6", "adduser", "libgcrypt20", "libgnutlsxx28", "libgpg-error0", "unzip", "p7zip-full", "procps", "libxslt1.1", "libedit2", "libenchant1c2a", "libqdbm14", "libltdl7", "zlib1g", "libtinfo5", "libtinfo6", "libgmp10", "libxml2", "libssl1.1", "libssl1.0.0", "openssl", "libcurl3-gnutls", "zlib1g", "libicu52", "libicu55", "libicu57", "libicu60", "libicu63"}};
+
 	try
 	{
 		_executablePath = executablePath;
@@ -83,6 +86,12 @@ void Settings::load(std::string filename, std::string executablePath)
 			GD::bl->out.printError("Unable to open config file: " + filename + ". " + strerror(errno));
 			return;
 		}
+
+	    for(auto& element : blackList)
+    	{
+        	_packagesBlacklist.emplace(element);
+    	}
+    	GD::bl->out.printDebug("Debug: packagesBlacklist was set");
 
 		while (fgets(input, 1024, fin))
 		{

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -59,6 +59,7 @@ public:
     std::unordered_set<std::string> allowedServiceCommands() { return _allowedServiceCommands; }
     std::unordered_set<std::string> controllableServices() { return _controllableServices; }
 	std::unordered_set<std::string> packagesWhitelist() { return _packagesWhitelist; }
+	std::unordered_set<std::string> packagesBlacklist() { return _packagesBlacklist; }
 	std::unordered_map<std::string, std::unordered_set<std::string>>& settingsWhitelist() { return _settingsWhitelist; }
 private:
 	std::string _executablePath;
@@ -83,6 +84,7 @@ private:
     std::unordered_set<std::string> _allowedServiceCommands;
     std::unordered_set<std::string> _controllableServices;
     std::unordered_set<std::string> _packagesWhitelist;
+	std::unordered_set<std::string> _packagesBlacklist;
     std::unordered_map<std::string, std::unordered_set<std::string>> _settingsWhitelist;
 
 	void reset();


### PR DESCRIPTION
…. Both are using the allready defined packagesWhitelist. A hardcoded list of packages protects managementAptDeinstallSpecific so that required packages cannot be removed