### PR TITLE
Bugfix: grep -v doesn't work combined, os-update not working

### DIFF
--- a/src/IpcClient.cpp
+++ b/src/IpcClient.cpp
@@ -1591,7 +1591,7 @@ Ipc::PVariable IpcClient::aptUpgrade(Ipc::PArray &parameters) {
     std::string output;
     std::ostringstream packages;
     if (parameters->at(0)->integerValue == 0) {
-      BaseLib::ProcessManager::exec("apt list --upgradable 2>/dev/null | grep -v homegear -v node-blue-node",
+      BaseLib::ProcessManager::exec("apt list --upgradable 2>/dev/null |grep -v homegear |grep -v node-blue-node",
                                     GD::bl->fileDescriptorManager.getMax(),
                                     output);
     } else if (parameters->at(0)->integerValue == 1) {


### PR DESCRIPTION
Original code:

```
# apt list --upgradable 2>/dev/null | grep -v homegear -v node-blue-node
grep: node-blue-node: No such file or directory
# 
```

Combined via 2 pipes:
```
# apt list --upgradable 2>/dev/null | grep -v homegear |grep -v node-blue-node
Listing...
armbian-firmware/stretch 20.08.17 all [upgradable from: 20.05.3]
base-files/oldstable 9.9+deb9u13 armhf [upgradable from: 9.9+deb9u12]
bind9-host/oldstable 1:9.10.3.dfsg.P4-12.3+deb9u7 armhf [upgradable from: 1:9.10.3.dfsg.P4-12.3+deb9u6]
curl/oldstable 7.52.1-5+deb9u12 armhf [upgradable from: 7.52.1-5+deb9u10]
dbus/oldstable 1.10.32-0+deb9u1 armhf [upgradable from: 1.10.28-0+deb9u1]
dnsutils/oldstable 1:9.10.3.dfsg.P4-12.3+deb9u7 armhf [upgradable from: 1:9.10.3.dfsg.P4-12.3+deb9u6]
e2fslibs/oldstable 1.43.4-2+deb9u2 armhf [upgradable from: 1.43.4-2+deb9u1]
e2fsprogs/oldstable 1.43.4-2+deb9u2 armhf [upgradable from: 1.43.4-2+deb9u1]
gir1.2-packagekitglib-1.0/oldstable 1.1.5-2+deb9u2 armhf [upgradable from: 1.1.5-2+deb9u1]
htop/stretch 3.1.0-0~armbian20.08.2+1 armhf [upgradable from: 2.1.2-3]
[...]
```