### PR TITLE
add SAN to certificate creation

### DIFF
--- a/src/IpcClient.cpp
+++ b/src/IpcClient.cpp
@@ -2070,12 +2070,13 @@ Ipc::PVariable IpcClient::createCert(Ipc::PArray &parameters) {
     metadata->structValue->emplace("keyPath",
                                    std::make_shared<Ipc::Variable>("/etc/homegear/ca/private/" + filename + ".key"));
 
-    return std::make_shared<Ipc::Variable>(startCommandThread("cd /etc/homegear/ca; openssl genrsa -out private/" + filename + ".key 4096; chown homegear:homegear private/"
+    return std::make_shared<Ipc::Variable>(startCommandThread("cd /etc/homegear/ca; echo \"subjectAltName=DNS:" + commonName + "\" > newcert.ext;"
+                                                                  + "openssl genrsa -out private/" + filename + ".key 4096; chown homegear:homegear private/"
                                                                   + filename + ".key; chmod 440 private/" + filename
                                                                   + ".key; openssl req -config /etc/homegear/openssl.cnf -new -key private/" + filename
                                                                   + ".key -out newcert.csr -subj \"/C=HG/ST=HG/L=HG/O=HG/CN=" + commonName
                                                                   + "\"; openssl ca -config /etc/homegear/openssl.cnf -in newcert.csr -out certs/" + filename
-                                                                  + ".crt -days 100000 -batch; rm newcert.csr",
+                                                                  + ".crt -extfile newcert.ext -days 100000 -batch; rm newcert.csr; rm newcert.ext",
                                                               false,
                                                               metadata));
   }


### PR DESCRIPTION
Hi @hfedcba, I've noticed that the X.509 certificates created by management (and then used by the RPC server) cannot be properly verified with more modern TLS clients. The problem is the missing "Subject Alternative Name" which causes the error `failed to verify certificate: x509: certificate relies on legacy Common Name field, use SANs instead` in Golang, for example. 
I have adapted the creation of the certificate so that the CN passed to the RPC function is also set as DNS SAN. If you then enter this CN as the servername/hostname in the TLS Config, the verification works so far.

If you agree with the change and there are no issues from your side, I would be happy if you would accept it.